### PR TITLE
Add option to use -p rtol and -d atol arguments simultaneously

### DIFF
--- a/tools/lib/h5diff_array.c
+++ b/tools/lib/h5diff_array.c
@@ -1395,15 +1395,17 @@ static hsize_t character_compare_opt(unsigned char *mem1, unsigned char *mem2, h
     /* -d and -p */
     else if (opts->delta_bool && opts->percent_bool) {
         PER_UNSIGN(signed char, temp1_uchar, temp2_uchar);
+        /*
         if (per > opts->percent && PDIFF(temp1_uchar,temp2_uchar) > opts->delta) {
+        */
+        if (PDIFF(temp1_uchar, temp2_uchar) > ((opts->percent)*temp1_uchar + opts->delta)) {
             opts->print_percentage = 1;
             print_pos(opts, elemtno, 0);
             if (print_data(opts)) {
                 parallel_print(I_FORMAT_P, temp1_uchar, temp2_uchar, PDIFF(temp1_uchar, temp2_uchar), per);
             }
             nfound++;
-        }
-    }
+        }    }
     else if (temp1_uchar != temp2_uchar) {
         opts->print_percentage = 0;
         print_pos(opts, elemtno, 0);
@@ -1549,7 +1551,11 @@ static hsize_t diff_float_element(unsigned char *mem1, unsigned char *mem2, hsiz
                 }
                 nfound++;
             }
+            /*
             else if (per > opts->percent && (double) ABS(temp1_float - temp2_float) > opts->delta) {
+            }
+            */
+            else if ((double) ABS(temp1_float - temp2_float) > ((opts->percent)*(double) temp1_float + opts->delta)) {
                 opts->print_percentage = 1;
                 print_pos(opts, elem_idx, 0);
                 if (print_data(opts)) {
@@ -1710,6 +1716,7 @@ static hsize_t diff_double_element(unsigned char *mem1, unsigned char *mem2, hsi
         if (!isnan1 && !isnan2) {
             PER(temp1_double, temp2_double);
 
+            /* A = 0, B != 0 */
             if (not_comparable && !both_zero)  {
                 opts->print_percentage = 1;
                 print_pos(opts, elem_idx, 0);
@@ -1718,7 +1725,11 @@ static hsize_t diff_double_element(unsigned char *mem1, unsigned char *mem2, hsi
                 }
                 nfound++;
             }
+            /* A != 0, B != 0 */
+            /*
             else if (per > opts->percent && ABS(temp1_double-temp2_double) > opts->delta) {
+            */
+            else if (ABS(temp1_double-temp2_double) > ((opts->percent)*temp1_double + opts->delta)) {
                 opts->print_percentage = 1;
                 print_pos(opts, elem_idx, 0);
                 if (print_data(opts)) {
@@ -1890,7 +1901,10 @@ static hsize_t diff_ldouble_element(unsigned char *mem1, unsigned char *mem2, hs
                 }
                 nfound++;
             }
+            /*
             else if (per > opts->percent && ABS(temp1_double-temp2_double) > opts->delta) {
+            */
+            else if (ABS(temp1_double-temp2_double) > ((opts->percent)*temp1_double + opts->delta)) {
                 opts->print_percentage = 1;
                 print_pos(opts, elem_idx, 0);
                 if (print_data(opts)) {
@@ -1992,7 +2006,10 @@ static hsize_t diff_schar_element(unsigned char *mem1, unsigned char *mem2, hsiz
             }
             nfound++;
         }
+        /* 
         else if (per > opts->percent && ABS(temp1_char - temp2_char) > opts->delta) {
+        */
+        else if (ABS(temp1_char - temp2_char) > ((opts->percent)*temp1_char + opts->delta)) {
             opts->print_percentage = 1;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {
@@ -2079,15 +2096,17 @@ static hsize_t diff_uchar_element(unsigned char *mem1, unsigned char *mem2, hsiz
             }
             nfound++;
         }
+        /*
         else if (per > opts->percent && PDIFF(temp1_uchar, temp2_uchar) > opts->delta) {
+        */
+        else if (PDIFF(temp1_uchar, temp2_uchar) > ((opts->percent)*temp1_uchar + opts->delta)) {
             opts->print_percentage = 1;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {
                 parallel_print(I_FORMAT_P, temp1_uchar, temp2_uchar, PDIFF(temp1_uchar, temp2_uchar), per);
             }
             nfound++;
-        }
-    }
+        }    }
     else if (temp1_uchar != temp2_uchar) {
         opts->print_percentage = 0;
         print_pos(opts, elem_idx, 0);
@@ -2166,7 +2185,10 @@ static hsize_t diff_short_element(unsigned char *mem1, unsigned char *mem2, hsiz
             }
             nfound++;
         }
+        /* 
         else if (per > opts->percent && ABS(temp1_short - temp2_short) > opts->delta) {
+        */
+        else if ((double)ABS(temp1_short - temp2_short) > ((opts->percent)*(double) temp1_short + opts->delta)) {
             opts->print_percentage = 1;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {
@@ -2253,7 +2275,10 @@ static hsize_t diff_ushort_element(unsigned char *mem1, unsigned char *mem2, hsi
             }
             nfound++;
         }
+        /*
         else if (per > opts->percent && PDIFF(temp1_ushort, temp2_ushort) > opts->delta) {
+        */
+        else if (PDIFF(temp1_ushort, temp2_ushort) > ((opts->percent)*temp1_ushort + opts->delta)) {
             opts->print_percentage = 1;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {
@@ -2340,7 +2365,10 @@ static hsize_t diff_int_element(unsigned char *mem1, unsigned char *mem2, hsize_
             }
             nfound++;
         }
+        /*
         else if (per > opts->percent && ABS(temp1_int - temp2_int) > opts->delta) {
+        */
+        else if (ABS(temp1_int - temp2_int) > ((opts->percent)*temp1_int + opts->delta)) {
             opts->print_percentage = 1;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {
@@ -2427,7 +2455,10 @@ static hsize_t diff_uint_element(unsigned char *mem1, unsigned char *mem2, hsize
             }
             nfound++;
         }
+        /*
         else if (per > opts->percent && PDIFF(temp1_uint,temp2_uint) > opts->delta) {
+        */
+        else if (PDIFF(temp1_uint, temp2_uint) > ((opts->percent)*temp1_uint + opts->delta)) {
             opts->print_percentage = 1;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {
@@ -2514,7 +2545,10 @@ static hsize_t diff_long_element(unsigned char *mem1, unsigned char *mem2, hsize
             }
             nfound++;
         }
+        /*
         else if (per > opts->percent && ABS(temp1_long-temp2_long) > opts->delta) {
+        */
+        else if (ABS(temp1_long - temp2_long) > ((opts->percent)*temp1_long + opts->delta)) {
             opts->print_percentage = 1;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {
@@ -2601,7 +2635,10 @@ static hsize_t diff_ulong_element(unsigned char *mem1, unsigned char *mem2, hsiz
             }
             nfound++;
         }
+        /*
         else if (per > opts->percent && PDIFF(temp1_ulong,temp2_ulong) > opts->delta) {
+        */
+        else if (PDIFF(temp1_ulong, temp2_ulong) > ((opts->percent)*temp1_ulong + opts->delta)) {
             opts->print_percentage = 1;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {
@@ -2689,7 +2726,10 @@ static hsize_t diff_llong_element(unsigned char *mem1, unsigned char *mem2, hsiz
             }
             nfound++;
         }
+        /*
         else if (per > opts->percent && ABS(temp1_llong-temp2_llong) > opts->delta) {
+        */
+        else if (ABS(temp1_llong - temp2_llong) > ((opts->percent)*temp1_llong + opts->delta)) {
             opts->print_percentage = 1;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {
@@ -2784,7 +2824,10 @@ static hsize_t diff_ullong_element(unsigned char *mem1, unsigned char *mem2, hsi
             }
             nfound++;
         }
+        /*
         else if (per > opts->percent && PDIFF(temp1_ullong,temp2_ullong) > (unsigned long long) opts->delta) {
+        */
+        else if (PDIFF(temp1_ullong, temp2_ullong) > ((opts->percent)*temp1_ullong + opts->delta)) {        
             opts->print_percentage = 1;
             print_pos(opts, elem_idx, 0);
             if (print_data(opts)) {

--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -61,9 +61,9 @@ static void check_options(diff_opt_t* opts)
     /* check between -d , -p, --use-system-epsilon.
      * These options are mutually exclusive.
      */
-    if ((opts->delta_bool + opts->percent_bool + opts->use_system_epsilon) > 1) {
-        HDprintf("%s error: -d, -p and --use-system-epsilon options are mutually-exclusive;\n", PROGRAMNAME);
-        HDprintf("use no more than one.\n");
+    //if ((opts->delta_bool + opts->percent_bool + opts->use_system_epsilon) > 1) {
+    if (((opts->delta_bool + opts->use_system_epsilon) > 1) || ((opts->percent_bool + opts->use_system_epsilon) > 1)) {
+        HDprintf("%s error: --use-system-epsilon option cannot be used as the same time as -d or -p options.\n");
         HDprintf("Try '-h' or '--help' option for more information or see the %s entry in the 'HDF5 Reference Manual'.\n", PROGRAMNAME);
         h5diff_exit(EXIT_FAILURE);
     }
@@ -639,11 +639,11 @@ void usage(void)
  PRINTVALSTREAM(rawoutstream, "   -d D, --delta=D\n");
  PRINTVALSTREAM(rawoutstream, "         Print difference if (|a-b| > D). D must be a positive number. Where a\n");
  PRINTVALSTREAM(rawoutstream, "         is the data point value in file1 and b is the data point value in file2.\n");
- PRINTVALSTREAM(rawoutstream, "         Can not use with '-p' or '--use-system-epsilon'.\n");
+ PRINTVALSTREAM(rawoutstream, "         Can not use with '--use-system-epsilon'.\n");
  PRINTVALSTREAM(rawoutstream, "   -p R, --relative=R\n");
  PRINTVALSTREAM(rawoutstream, "         Print difference if (|(a-b)/b| > R). R must be a positive number. Where a\n");
  PRINTVALSTREAM(rawoutstream, "         is the data point value in file1 and b is the data point value in file2.\n");
- PRINTVALSTREAM(rawoutstream, "         Can not use with '-d' or '--use-system-epsilon'.\n");
+ PRINTVALSTREAM(rawoutstream, "         Can not use with '--use-system-epsilon'.\n");
  PRINTVALSTREAM(rawoutstream, "   --use-system-epsilon\n");
  PRINTVALSTREAM(rawoutstream, "         Print difference if (|a-b| > EPSILON), EPSILON is system defined value. Where a\n");
  PRINTVALSTREAM(rawoutstream, "         is the data point value in file1 and b is the data point value in file2.\n");


### PR DESCRIPTION
Report difference between x and y when err < (rtol * x + atol)

I see some warning messages during compile. Will these affect accuracy of the results?
```
h5diff_array.c: In function ?diff_long_element?:
h5diff_array.c:2551:65: warning: conversion to ?double? from ?long int? may alter its value [-Wconversion]
         else if (ABS(temp1_long - temp2_long) > ((opts->percent)*temp1_long + opts->delta)) {
                                                                 ^
h5diff_array.c: In function ?diff_ulong_element?:
h5diff_array.c:2641:68: warning: conversion to ?double? from ?long unsigned int? may alter its value [-Wconversion]
         else if (PDIFF(temp1_ulong, temp2_ulong) > ((opts->percent)*temp1_ulong + opts->delta)) {
                                                                    ^
h5diff_array.c: In function ?diff_llong_element?:
h5diff_array.c:2732:67: warning: conversion to ?double? from ?long long int? may alter its value [-Wconversion]
         else if (ABS(temp1_llong - temp2_llong) > ((opts->percent)*temp1_llong + opts->delta)) {
                                                                   ^
h5diff_array.c: In function ?diff_ullong_element?:
h5diff_array.c:2830:70: warning: conversion to ?double? from ?long long unsigned int? may alter its value [-Wconversion]
         else if (PDIFF(temp1_ullong, temp2_ullong) > ((opts->percent)*temp1_ullong + opts->delta)) {
```